### PR TITLE
Add GUI client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements and install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Default command to run the main script
+CMD ["python", "Main.py"]

--- a/Main.py
+++ b/Main.py
@@ -26,7 +26,7 @@ from pruning import prune_toolpath_steps
 from scan_utils import reorder_scan_points_by_normals
 import gridpattern
 
-def main():
+def main(stl_file_path="TorpedoMockup.STL"):
     """@brief Entry point for toolpath planning demo.
 
     Demonstrates the complete workflow from loading the part mesh to generating
@@ -38,7 +38,6 @@ def main():
     debug_obstacles_only = False    
 
     # --- Part and Environment Setup ---
-    stl_file_path = r"C:\Users\robbi\Documents\STL\TorpedoMockup.stl" 
 
     part_front_surface_global_origin = np.array([1050, 0, 250]) 
     
@@ -281,4 +280,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    stl_path_cli = sys.argv[1] if len(sys.argv) > 1 else "TorpedoMockup.STL"
+    main(stl_path_cli)

--- a/client_gui.py
+++ b/client_gui.py
@@ -1,0 +1,54 @@
+import tkinter as tk
+from tkinter import filedialog, ttk, messagebox
+import threading
+import os
+import Main
+
+
+def _run_pipeline(path, button):
+    try:
+        Main.main(path)
+    except Exception as exc:
+        messagebox.showerror("Error", str(exc))
+    finally:
+        button.config(state=tk.NORMAL)
+
+
+def start_planning(stl_var, button):
+    path = stl_var.get()
+    if not os.path.isfile(path):
+        messagebox.showerror("Invalid File", "Please select a valid STL file")
+        return
+    button.config(state=tk.DISABLED)
+    threading.Thread(target=_run_pipeline, args=(path, button), daemon=True).start()
+
+
+def create_gui():
+    root = tk.Tk()
+    root.title("Toolpath Planner")
+
+    frame = ttk.Frame(root, padding=10)
+    frame.pack(fill=tk.BOTH, expand=True)
+
+    stl_var = tk.StringVar()
+
+    ttk.Label(frame, text="STL File:").grid(row=0, column=0, sticky=tk.W)
+    entry = ttk.Entry(frame, textvariable=stl_var, width=40)
+    entry.grid(row=0, column=1, sticky=tk.EW)
+
+    def browse():
+        file_path = filedialog.askopenfilename(filetypes=[("STL Files", "*.stl"), ("All Files", "*.*")])
+        if file_path:
+            stl_var.set(file_path)
+
+    ttk.Button(frame, text="Browse", command=browse).grid(row=0, column=2, padx=5)
+
+    run_btn = ttk.Button(frame, text="Run", command=lambda: start_planning(stl_var, run_btn))
+    run_btn.grid(row=1, column=0, columnspan=3, pady=10)
+
+    frame.columnconfigure(1, weight=1)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    create_gui()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+trimesh
+plotly
+scikit-learn
+tqdm
+pyserial


### PR DESCRIPTION
## Summary
- parameterize `Main.main` to accept STL path and CLI arg
- add `client_gui.py` to provide a simple Tkinter GUI to run the toolpath planner

## Testing
- `pip install -r requirements.txt`
- `pip check`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68468c48c228833095734d47f149e1d5