### PR TITLE
Add GUI toolpath runner with G-code conversion

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -26,13 +26,14 @@ from pruning import prune_toolpath_steps
 from scan_utils import reorder_scan_points_by_normals
 import gridpattern # Importing gridpattern for scan point generation
 
-def main():
+def main(stl_file_path=None):
     # --- Debug Flags and High-Level Parameters ---
     debug_flip_part = True        
     debug_obstacles_only = False    
 
     # --- Part and Environment Setup ---
-    stl_file_path = r"C:\Users\robbi\Documents\STL\TorpedoMockup.stl" 
+    if stl_file_path is None:
+        stl_file_path = r"C:\Users\robbi\Documents\STL\TorpedoMockup.stl"
 
     part_front_surface_global_origin = np.array([1050, 0, 250]) 
     
@@ -244,8 +245,8 @@ def main():
     axis_length_for_viz = 180 
     animation_frame_duration_ms = 50 
 
-    animate_toolpath(
-        toolpath=pruned_toolpath_steps, 
+    figs = animate_toolpath(
+        toolpath=pruned_toolpath_steps,
         stl_mesh=processed_stl_mesh, 
         part_origin=part_global_center_origin, 
         part_y_axis=part_turntable_y_axis, 
@@ -263,7 +264,8 @@ def main():
         display_animation=True,
         collision_manager=env_collision_manager if env_collision_manager and env_collision_manager._objs else None, 
         debug_obstacles_only=debug_obstacles_only,
-        split_animation_halves=True
+        split_animation_halves=True,
+        return_figures=True
     )
 
     # Clean up temporary file
@@ -272,6 +274,8 @@ def main():
             os.remove(temp_scaled_stl_file)
         except OSError as e:
             print(f"Error removing temporary file {temp_scaled_stl_file}: {e}")
+
+    return figs
 
 
 if __name__ == "__main__":

--- a/toolpath_gui.py
+++ b/toolpath_gui.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+import os
+import sys
+import threading
+import queue
+import numpy as np
+from PyQt6 import QtWidgets, QtWebEngineWidgets
+from PyQt6.QtCore import QUrl
+import plotly.io as pio
+
+import transmitter
+from command_sender import reader_task, wait_for_ack
+from robot import Robot, Laser
+import Main
+
+PORT = "COM9"
+BAUD = 921600
+CHUCK_DRAWBACK_DISTANCE_MM = 30.0
+
+def convert_npy_to_gcode(
+    npy_path: str, gcode_path: str,
+    drawback_dist: float = CHUCK_DRAWBACK_DISTANCE_MM
+) -> None:
+    data = np.load(npy_path)
+    with open(gcode_path, "w", encoding="utf-8") as f:
+        f.write("G28 A\0\n")
+        for i, row in enumerate(data):
+            angle_rad = np.deg2rad(row[7])
+            pull_back = bool(row[8])
+            next_same_angle_and_pullback = False
+            if pull_back and i < len(data) - 1:
+                next_row = data[i + 1]
+                next_angle_rad = np.deg2rad(next_row[7])
+                next_pull_back = bool(next_row[8])
+                if np.isclose(next_angle_rad, angle_rad) and next_pull_back:
+                    next_same_angle_and_pullback = True
+
+            if pull_back:
+                f.write(f"G01 A{angle_rad:.4f} C-30.0\0\n")
+                f.write(
+                    f"G01 A{angle_rad:.4f} Y{drawback_dist} C-30.0\0\n"
+                )
+                if not next_same_angle_and_pullback:
+                    f.write(
+                        f"G01 A{angle_rad:.4f} Y-{drawback_dist} C0\0\n"
+                    )
+            else:
+                f.write(f"G01 A{angle_rad:.4f}\0\n")
+
+        f.write("G01 A0 Y0\0\n")
+        f.write("G01 A0 Y0 C0\0\n")
+
+
+def run_toolpath(npy_path: str, drawback_dist: float = CHUCK_DRAWBACK_DISTANCE_MM) -> None:
+    commands = np.load(npy_path)
+    robot = Robot()
+
+    tx = transmitter.Transmitter(PORT, BAUD, write_timeout=None, timeout=None)
+    log_q: queue.Queue[str] = queue.Queue()
+    threading.Thread(target=reader_task, args=(tx.serial, log_q), daemon=True).start()
+
+    def send(cmd: str):
+        if not cmd.endswith("\0"):
+            cmd += "\0"
+        tx.send_msg(transmitter.CommandMessage(cmd))
+        wait_for_ack(log_q)
+
+    send("G28 A")
+
+    for i, step in enumerate(commands):
+        angle_rad = np.deg2rad(step[7])
+        pull_back = bool(step[8])
+
+        next_same_angle_and_pullback = False
+        if pull_back and i < len(commands) - 1:
+            next_step = commands[i + 1]
+            next_angle_rad = np.deg2rad(next_step[7])
+            next_pull_back = bool(next_step[8])
+            if np.isclose(next_angle_rad, angle_rad) and next_pull_back:
+                next_same_angle_and_pullback = True
+
+        if pull_back:
+            send(f"G01 A{angle_rad:.4f} C-30.0")
+            send(f"G01 A{angle_rad:.4f} Y{drawback_dist} C-30.0")
+        else:
+            send(f"G01 A{angle_rad:.4f}")
+
+        quat_xyzw = [step[4], step[5], step[6], step[3]]
+        robot_pos = np.array([step[0], step[1], step[2], *quat_xyzw])
+        robot.step(robot_pos)
+        Laser.ablate()
+
+        if pull_back and not next_same_angle_and_pullback:
+            send(f"G01 A{angle_rad:.4f} Y-{drawback_dist} C0")
+
+    send("G01 A0 Y0")
+    send("G01 A0 Y0 C0")
+
+
+class ToolpathGUI(QtWidgets.QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Toolpath Runner")
+        self.resize(1000, 800)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        btn_layout = QtWidgets.QHBoxLayout()
+        self.load_btn = QtWidgets.QPushButton("Use Existing Commands")
+        self.gen_btn = QtWidgets.QPushButton("Generate New Toolpath")
+        btn_layout.addWidget(self.load_btn)
+        btn_layout.addWidget(self.gen_btn)
+        layout.addLayout(btn_layout)
+
+        self.web_view = QtWebEngineWidgets.QWebEngineView()
+        layout.addWidget(self.web_view, 1)
+
+        self.run_btn = QtWidgets.QPushButton("Run Toolpath")
+        self.run_btn.setEnabled(False)
+        layout.addWidget(self.run_btn)
+
+        self.npy_path: str | None = None
+        self.html_temp: str | None = None
+
+        self.load_btn.clicked.connect(self.load_existing)
+        self.gen_btn.clicked.connect(self.generate_toolpath)
+        self.run_btn.clicked.connect(self.execute_toolpath)
+
+    def display_figures(self, figs):
+        if not figs:
+            return
+        html = "".join(pio.to_html(fig, include_plotlyjs='cdn', full_html=False) for fig in figs)
+        tmp = os.path.abspath("_temp_plot.html")
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(html)
+        self.web_view.load(QUrl.fromLocalFile(tmp))
+        self.html_temp = tmp
+
+    def load_existing(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Select ee_robot_commands.npy", os.getcwd(), "NumPy Files (*.npy)")
+        if path:
+            self.npy_path = path
+            QtWidgets.QMessageBox.information(self, "Loaded", f"Loaded {os.path.basename(path)}. No preview available.")
+            self.run_btn.setEnabled(True)
+
+    def generate_toolpath(self):
+        stl_path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Select STL file", os.getcwd(), "STL Files (*.stl)")
+        if not stl_path:
+            return
+        figs = Main.main(stl_path)
+        self.npy_path = "ee_robot_commands.npy"
+        self.display_figures(figs)
+        self.run_btn.setEnabled(True)
+
+    def execute_toolpath(self):
+        if not self.npy_path:
+            return
+        run_toolpath(self.npy_path)
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication(sys.argv)
+    gui = ToolpathGUI()
+    gui.show()
+    sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- extend `animate_toolpath` to optionally return Plotly figures
- update `Main.main` to accept an STL path parameter and return animation figures
- create `toolpath_gui.py` to convert ee_robot_commands to G-code and run toolpaths with a PyQt6 GUI
- refine pullback G-code logic so the chuck only draws forward when needed
- switch GUI implementation to PyQt6 and WebEngine

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68472695de24833086f2fe73f2b3249e